### PR TITLE
Fixed progress indicator

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -2,6 +2,6 @@ Package: s3duck
 Version: _version_
 Architecture: amd64
 Maintainer: Vladislav Ananev <nexus.riot@gmail.com>
-Description:Simple free cross-platform client for Simple Storage Service.
+Description:Simple Opensource cross-platform client for Simple Storage Service.
 Installed-Size: 58
 Depends: python3 (>=3.6), python3-boto3, python3-cryptography, python3-pyqt5

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -1,6 +1,6 @@
 #!/bin/env bash
 
-version=0.1.2
+version=0.1.3
 
 echo "building deb for s3duck $version"
 


### PR DESCRIPTION
1. Made Thread-safe _BotoProgressAdapter
2. Safer Worker.upload(), download()
3. Fixed UI progress indicator for the large files

For very large objects, boto3 calls callback with total_file=None. When total_file is None, we send garbage to the UI math. That garbage makes us think we're “done_all == total_bytes_all” almost immediately → jumps to 100%.

On smaller files, boto3 does give total_file, so it behaves.

pyqtSignal(int, int, str) is too small for multi-GB.